### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/MenschMachine/propagate/security/code-scanning/2](https://github.com/MenschMachine/propagate/security/code-scanning/2)

In general, the fix is to explicitly specify `permissions` for the workflow or for each job, granting only the minimal scopes required. Since both `lint` and `test` jobs only need to read the repository contents, they can share a single root-level `permissions` block with `contents: read`.

The best minimal change is to add a `permissions:` block at the top level of `.github/workflows/ci.yml`, between the `on:` block and the `jobs:` block. This will apply to all jobs that do not have their own `permissions` setting. No changes are needed to individual steps or to the actions used, and no additional imports or external libraries are required.

Concretely: in `.github/workflows/ci.yml`, after line 7 (the last line of the `on:` section) and before line 9 (`jobs:`), add:

```yaml
permissions:
  contents: read
```

This constrains the `GITHUB_TOKEN` used by both `lint` and `test` to have only read access to repository contents, fully addressing the CodeQL warning without altering workflow behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
